### PR TITLE
fix: detailed search

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,9 @@ export default defineConfig({
   themeConfig: {
     search: {
       provider: 'local',
+      options: {
+        detailedView: true
+      }
     },
     nav: [
       { text: 'Home', link: '/' },


### PR DESCRIPTION
Simply enabled detailed search by default for results which is much better for viewing search results.