### PR TITLE
Fetch sdk modules from go program

### DIFF
--- a/scripts/fetch_sdk_modules.go
+++ b/scripts/fetch_sdk_modules.go
@@ -66,8 +66,8 @@ func fetchSDKModules(srcFile string) ([]string, error) {
 	for _, modName := range modNames {
 		for _, imp := range f.Imports {
 			path := imp.Path.Value
-			path = path[1 : len(path)-1]              // remove quotes
-			path = strings.TrimSuffix(path, "module") // remove potential extra module path
+			path = path[1 : len(path)-1]               // remove quotes
+			path = strings.TrimSuffix(path, "/module") // remove potential extra module path
 			impName := filepath.Base(path)
 			if imp.Name != nil {
 				// import use an alias


### PR DESCRIPTION
The program reads the file in argument and outputs the path of the SDK modules into a JSON array.

Example:
```sh
$ go run ./scripts/fetch_sdk_modules.go -- ./atomone/app/modules.go
[
  "github.com/cosmos/cosmos-sdk/x/auth",
  "github.com/cosmos/cosmos-sdk/x/authz",
  "github.com/cosmos/cosmos-sdk/x/bank",
  "github.com/cosmos/cosmos-sdk/x/capability",
  "github.com/cosmos/cosmos-sdk/x/consensus",
  "github.com/cosmos/cosmos-sdk/x/crisis",
  "github.com/cosmos/cosmos-sdk/x/distribution",
  "github.com/cosmos/cosmos-sdk/x/evidence",
  "github.com/cosmos/cosmos-sdk/x/feegrant",
  "github.com/cosmos/cosmos-sdk/x/genutil",
  "github.com/atomone-hub/atomone/x/gov",
  "github.com/cosmos/ibc-go/v7/modules/core",
  "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint",
  "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts",
  "github.com/cosmos/cosmos-sdk/x/mint",
  "github.com/atomone-hub/atomone/x/photon",
  "github.com/cosmos/cosmos-sdk/x/params",
  "github.com/cosmos/cosmos-sdk/x/slashing",
  "github.com/cosmos/cosmos-sdk/x/staking",
  "github.com/cosmos/ibc-go/v7/modules/apps/transfer",
  "github.com/cosmos/cosmos-sdk/x/upgrade",
  "github.com/cosmos/cosmos-sdk/x/auth/vesting"
]
```

Notes:
- You can probably ignore the modules that comes from `ibc-go`, and consider only the one from the cosmos-sdk and atomone repo.
- the double `--` in the command line is mandatory, the command will fail w/o it. This is bc of how `go run` works.